### PR TITLE
add remove-binding codemod with tests and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,8 @@ node ./bin/cli.js <TRANSFORM NAME> path/of/files/ or/some**/*glob.js
 ## Transforms
 
 <!--TRANSFORMS_START-->
-`[contains-to-includes](transforms/contains-to-includes/README.md)` Ember 2.8 introduced a new [deprecation](https://deprecations.emberjs.com/v2.x#toc_ember-runtime-enumerable-contains) to remove the use of `contains` for `includes` for `Enumerable` and `Array`, this codemod will change migrate all such occurrences for you.
-
-`[remove-binding](transforms/remove-binding/README.md)` Ember 2.7 introduced a [new deprecation to EmberBinding](https://deprecations.emberjs.com/v2.x#toc_ember-binding). This codemod aims to convert all existing uses of `fooBinding: 'path.to.property'` to `foo: alias('path.to.property')`.
+* [contains-to-includes](transforms/contains-to-includes/README.md)
+* [remove-binding](transforms/remove-binding/README.md)
 <!--TRANSFORMS_END-->
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ node ./bin/cli.js <TRANSFORM NAME> path/of/files/ or/some**/*glob.js
 <!--TRANSFORMS_START-->
 `[contains-to-includes](transforms/contains-to-includes/README.md)` Ember 2.8 introduced a new [deprecation](https://deprecations.emberjs.com/v2.x#toc_ember-runtime-enumerable-contains) to remove the use of `contains` for `includes` for `Enumerable` and `Array`, this codemod will change migrate all such occurrences for you.
 
-`[remove-binding](transforms/remove-binding/README.md)` Ember 2.7 introduced a new deprecation to EmberBinding https://deprecations.emberjs.com/v2.x#toc_ember-binding. This codemod aims to convert all existing uses of `fooBinding: 'path.to.property'` to `foo: alias('path.to.property')`.
+`[remove-binding](transforms/remove-binding/README.md)` Ember 2.7 introduced a [new deprecation to EmberBinding](https://deprecations.emberjs.com/v2.x#toc_ember-binding). This codemod aims to convert all existing uses of `fooBinding: 'path.to.property'` to `foo: alias('path.to.property')`.
 <!--TRANSFORMS_END-->
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ node ./bin/cli.js <TRANSFORM NAME> path/of/files/ or/some**/*glob.js
 
 <!--TRANSFORMS_START-->
 `[contains-to-includes](transforms/contains-to-includes/README.md)` Ember 2.8 introduced a new [deprecation](https://deprecations.emberjs.com/v2.x#toc_ember-runtime-enumerable-contains) to remove the use of `contains` for `includes` for `Enumerable` and `Array`, this codemod will change migrate all such occurrences for you.
+
+`[remove-binding](transforms/remove-binding/README.md)` Ember 2.7 introduced a new deprecation to EmberBinding https://deprecations.emberjs.com/v2.x#toc_ember-binding. This codemod aims to convert all existing uses of `fooBinding: 'path.to.property'` to `foo: alias('path.to.property')`.
 <!--TRANSFORMS_END-->
 
 ## Contributing

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "repository": "git@github.com:Mainmatter/ember2-x-codemods.git",
   "scripts": {
     "lint": "eslint --cache .",
-    "test": "codemod-cli test --passWithNoTests",
+    "test": "codemod-cli test",
     "test:coverage": "codemod-cli test --coverage",
     "release": "release-it --dry-run",
     "update-docs": "codemod-cli update-docs",

--- a/transforms/contains-to-includes/README.md
+++ b/transforms/contains-to-includes/README.md
@@ -21,13 +21,39 @@ node ./bin/cli.js contains-to-includes path/of/files/ or/some**/*glob.js
 ## Input / Output
 
 <!--FIXTURES_TOC_START-->
-```js
-[1,2,3].contains(1);
-```
+* [array-expression](#array-expression)
+* [variable](#variable)
 <!--FIXTURES_TOC_END-->
 
 <!--FIXTURES_CONTENT_START-->
+---
+<a id="array-expression">**array-expression**</a>
+
+**Input** (<small>[array-expression.input.js](transforms/contains-to-includes/__testfixtures__/array-expression.input.js)</small>):
+```js
+[1,2,3].contains(1);
+
+```
+
+**Output** (<small>[array-expression.output.js](transforms/contains-to-includes/__testfixtures__/array-expression.output.js)</small>):
 ```js
 [1,2,3].includes(1);
+
+```
+---
+<a id="variable">**variable**</a>
+
+**Input** (<small>[variable.input.js](transforms/contains-to-includes/__testfixtures__/variable.input.js)</small>):
+```js
+let arr = [1,2,3];
+arr.contains(1);
+
+```
+
+**Output** (<small>[variable.output.js](transforms/contains-to-includes/__testfixtures__/variable.output.js)</small>):
+```js
+let arr = [1,2,3];
+arr.includes(1);
+
 ```
 <!--FIXTURES_CONTENT_END-->

--- a/transforms/remove-binding/README.md
+++ b/transforms/remove-binding/README.md
@@ -1,5 +1,5 @@
 # remove-binding
-Ember 2.7 introduced a new deprecation to EmberBinding https://deprecations.emberjs.com/v2.x#toc_ember-binding. This codemod aims to convert all existing uses of `fooBinding: 'path.to.property'` to `foo: alias('path.to.property')` and if the current file does not have the alias import the following line will also be added `import { alias } from '@ember/object/computed';`
+Ember 2.7 introduced a [new deprecation to EmberBinding](https://deprecations.emberjs.com/v2.x#toc_ember-binding). This codemod aims to convert all existing uses of `fooBinding: 'path.to.property'` to `foo: alias('path.to.property')` and if the current file does not have the alias import the following line will also be added `import { alias } from '@ember/object/computed';`
 
 
 ## Usage

--- a/transforms/remove-binding/README.md
+++ b/transforms/remove-binding/README.md
@@ -21,18 +21,145 @@ node ./bin/cli.js remove-binding path/of/files/ or/some**/*glob.js
 ## Input / Output
 
 <!--FIXTURES_TOC_START-->
-```js
-let obj = {
-  testBinding: 'this.app',
-}
-```
+* [alreadyHasComputedImport](#alreadyHasComputedImport)
+* [alreadyImported](#alreadyImported)
+* [basic](#basic)
+* [classBindings](#classBindings)
+* [importWithNamedAndDefaultImport](#importWithNamedAndDefaultImport)
+* [importWithoutNamedImport](#importWithoutNamedImport)
+* [randomProperty](#randomProperty)
 <!--FIXTURES_TOC_END-->
 
 <!--FIXTURES_CONTENT_START-->
+---
+<a id="alreadyHasComputedImport">**alreadyHasComputedImport**</a>
+
+**Input** (<small>[alreadyHasComputedImport.input.js](transforms/remove-binding/__testfixtures__/alreadyHasComputedImport.input.js)</small>):
+```js
+import { not } from '@ember/object/computed';
+let obj = {
+  testBinding: 'this.app',
+}
+
+```
+
+**Output** (<small>[alreadyHasComputedImport.output.js](transforms/remove-binding/__testfixtures__/alreadyHasComputedImport.output.js)</small>):
+```js
+import { not, alias } from '@ember/object/computed';
+let obj = {
+  test: alias('this.app'),
+}
+
+```
+---
+<a id="alreadyImported">**alreadyImported**</a>
+
+**Input** (<small>[alreadyImported.input.js](transforms/remove-binding/__testfixtures__/alreadyImported.input.js)</small>):
+```js
+import { alias } from '@ember/object/computed';
+let obj = {
+  testBinding: 'this.app',
+}
+
+```
+
+**Output** (<small>[alreadyImported.output.js](transforms/remove-binding/__testfixtures__/alreadyImported.output.js)</small>):
 ```js
 import { alias } from '@ember/object/computed';
 let obj = {
   test: alias('this.app'),
 }
+
+```
+---
+<a id="basic">**basic**</a>
+
+**Input** (<small>[basic.input.js](transforms/remove-binding/__testfixtures__/basic.input.js)</small>):
+```js
+let obj = {
+  testBinding: 'this.app',
+}
+
+```
+
+**Output** (<small>[basic.output.js](transforms/remove-binding/__testfixtures__/basic.output.js)</small>):
+```js
+import { alias } from '@ember/object/computed';
+let obj = {
+  test: alias('this.app'),
+}
+
+```
+---
+<a id="classBindings">**classBindings**</a>
+
+**Input** (<small>[classBindings.input.js](transforms/remove-binding/__testfixtures__/classBindings.input.js)</small>):
+```js
+let obj = {
+  classBindings: ['class'],
+}
+
+```
+
+**Output** (<small>[classBindings.output.js](transforms/remove-binding/__testfixtures__/classBindings.output.js)</small>):
+```js
+let obj = {
+  classBindings: ['class'],
+}
+
+```
+---
+<a id="importWithNamedAndDefaultImport">**importWithNamedAndDefaultImport**</a>
+
+**Input** (<small>[importWithNamedAndDefaultImport.input.js](transforms/remove-binding/__testfixtures__/importWithNamedAndDefaultImport.input.js)</small>):
+```js
+import Computed, { not } from '@ember/object/computed';
+let obj = {
+  testBinding: 'this.app',
+};
+```
+
+**Output** (<small>[importWithNamedAndDefaultImport.output.js](transforms/remove-binding/__testfixtures__/importWithNamedAndDefaultImport.output.js)</small>):
+```js
+import Computed, { not, alias } from '@ember/object/computed';
+let obj = {
+  test: alias('this.app'),
+};
+```
+---
+<a id="importWithoutNamedImport">**importWithoutNamedImport**</a>
+
+**Input** (<small>[importWithoutNamedImport.input.js](transforms/remove-binding/__testfixtures__/importWithoutNamedImport.input.js)</small>):
+```js
+import Computed from '@ember/object/computed';
+let obj = {
+  testBinding: 'this.app',
+};
+```
+
+**Output** (<small>[importWithoutNamedImport.output.js](transforms/remove-binding/__testfixtures__/importWithoutNamedImport.output.js)</small>):
+```js
+import Computed, { alias } from '@ember/object/computed';
+let obj = {
+  test: alias('this.app'),
+};
+```
+---
+<a id="randomProperty">**randomProperty**</a>
+
+**Input** (<small>[randomProperty.input.js](transforms/remove-binding/__testfixtures__/randomProperty.input.js)</small>):
+```js
+let obj = {
+  randomProperty: 'this.app',
+}
+
+```
+
+**Output** (<small>[randomProperty.output.js](transforms/remove-binding/__testfixtures__/randomProperty.output.js)</small>):
+```js
+let obj = {
+  randomProperty: 'this.app',
+}
+
 ```
 <!--FIXTURES_CONTENT_END-->

--- a/transforms/remove-binding/README.md
+++ b/transforms/remove-binding/README.md
@@ -1,0 +1,38 @@
+# remove-binding
+Ember 2.7 introduced a new deprecation to EmberBinding https://deprecations.emberjs.com/v2.x#toc_ember-binding. This codemod aims to convert all existing uses of `fooBinding: 'path.to.property'` to `foo: alias('path.to.property')` and if the current file does not have the alias import the following line will also be added `import { alias } from '@ember/object/computed';`
+
+
+## Usage
+
+```
+npx ember2-x-codemods remove-binding path/of/files/ or/some**/*glob.js
+
+# or
+
+yarn global add ember2-x-codemods
+ember2-x-codemods remove-binding path/of/files/ or/some**/*glob.js
+```
+
+## Local Usage
+```
+node ./bin/cli.js remove-binding path/of/files/ or/some**/*glob.js
+```
+
+## Input / Output
+
+<!--FIXTURES_TOC_START-->
+```js
+let obj = {
+  testBinding: 'this.app',
+}
+```
+<!--FIXTURES_TOC_END-->
+
+<!--FIXTURES_CONTENT_START-->
+```js
+import { alias } from '@ember/object/computed';
+let obj = {
+  test: alias('this.app'),
+}
+```
+<!--FIXTURES_CONTENT_END-->

--- a/transforms/remove-binding/__testfixtures__/alreadyHasComputedImport.input.js
+++ b/transforms/remove-binding/__testfixtures__/alreadyHasComputedImport.input.js
@@ -1,0 +1,4 @@
+import { not } from '@ember/object/computed';
+let obj = {
+  testBinding: 'this.app',
+}

--- a/transforms/remove-binding/__testfixtures__/alreadyHasComputedImport.output.js
+++ b/transforms/remove-binding/__testfixtures__/alreadyHasComputedImport.output.js
@@ -1,0 +1,4 @@
+import { not, alias } from '@ember/object/computed';
+let obj = {
+  test: alias('this.app'),
+}

--- a/transforms/remove-binding/__testfixtures__/alreadyImported.input.js
+++ b/transforms/remove-binding/__testfixtures__/alreadyImported.input.js
@@ -1,0 +1,4 @@
+import { alias } from '@ember/object/computed';
+let obj = {
+  testBinding: 'this.app',
+}

--- a/transforms/remove-binding/__testfixtures__/alreadyImported.output.js
+++ b/transforms/remove-binding/__testfixtures__/alreadyImported.output.js
@@ -1,0 +1,4 @@
+import { alias } from '@ember/object/computed';
+let obj = {
+  test: alias('this.app'),
+}

--- a/transforms/remove-binding/__testfixtures__/basic.input.js
+++ b/transforms/remove-binding/__testfixtures__/basic.input.js
@@ -1,0 +1,3 @@
+let obj = {
+  testBinding: 'this.app',
+}

--- a/transforms/remove-binding/__testfixtures__/basic.output.js
+++ b/transforms/remove-binding/__testfixtures__/basic.output.js
@@ -1,0 +1,4 @@
+import { alias } from '@ember/object/computed';
+let obj = {
+  test: alias('this.app'),
+}

--- a/transforms/remove-binding/__testfixtures__/classBindings.input.js
+++ b/transforms/remove-binding/__testfixtures__/classBindings.input.js
@@ -1,0 +1,3 @@
+let obj = {
+  classBindings: ['class'],
+}

--- a/transforms/remove-binding/__testfixtures__/classBindings.output.js
+++ b/transforms/remove-binding/__testfixtures__/classBindings.output.js
@@ -1,0 +1,3 @@
+let obj = {
+  classBindings: ['class'],
+}

--- a/transforms/remove-binding/__testfixtures__/importWithNamedAndDefaultImport.input.js
+++ b/transforms/remove-binding/__testfixtures__/importWithNamedAndDefaultImport.input.js
@@ -1,0 +1,4 @@
+import Computed, { not } from '@ember/object/computed';
+let obj = {
+  testBinding: 'this.app',
+};

--- a/transforms/remove-binding/__testfixtures__/importWithNamedAndDefaultImport.output.js
+++ b/transforms/remove-binding/__testfixtures__/importWithNamedAndDefaultImport.output.js
@@ -1,0 +1,4 @@
+import Computed, { not, alias } from '@ember/object/computed';
+let obj = {
+  test: alias('this.app'),
+};

--- a/transforms/remove-binding/__testfixtures__/importWithoutNamedImport.input.js
+++ b/transforms/remove-binding/__testfixtures__/importWithoutNamedImport.input.js
@@ -1,0 +1,4 @@
+import Computed from '@ember/object/computed';
+let obj = {
+  testBinding: 'this.app',
+};

--- a/transforms/remove-binding/__testfixtures__/importWithoutNamedImport.output.js
+++ b/transforms/remove-binding/__testfixtures__/importWithoutNamedImport.output.js
@@ -1,0 +1,4 @@
+import Computed, { alias } from '@ember/object/computed';
+let obj = {
+  test: alias('this.app'),
+};

--- a/transforms/remove-binding/__testfixtures__/randomProperty.input.js
+++ b/transforms/remove-binding/__testfixtures__/randomProperty.input.js
@@ -1,0 +1,3 @@
+let obj = {
+  randomProperty: 'this.app',
+}

--- a/transforms/remove-binding/__testfixtures__/randomProperty.output.js
+++ b/transforms/remove-binding/__testfixtures__/randomProperty.output.js
@@ -1,0 +1,3 @@
+let obj = {
+  randomProperty: 'this.app',
+}

--- a/transforms/remove-binding/index.js
+++ b/transforms/remove-binding/index.js
@@ -11,7 +11,7 @@ module.exports = function transformer(file, api) {
     },
   });
 
-  let filteredNodes = node.filter((path) => {
+  let nodesWithBindings = node.filter((path) => {
     return path.value.key.name && path.value.key.name.endsWith('Binding');
   });
 
@@ -27,7 +27,7 @@ module.exports = function transformer(file, api) {
       .get()
       .node.specifiers.filter((specifier) => specifier.imported.name === 'alias');
 
-  if (!alreadyHasAlias[0] && filteredNodes.length) {
+  if (!alreadyHasAlias[0] && nodesWithBindings.length) {
     if (computedImports.length) {
       let aliasSpecifier = j.importSpecifier(j.identifier('alias'));
       computedImports.get().value.specifiers.push(aliasSpecifier);
@@ -41,7 +41,7 @@ module.exports = function transformer(file, api) {
     }
   }
 
-  filteredNodes.forEach((path) => {
+  nodesWithBindings.forEach((path) => {
     path.value.value = j.callExpression(j.identifier('alias'), [path.value.value]);
     path.value.key.name = path.value.key.name.slice(0, -7);
   });

--- a/transforms/remove-binding/index.js
+++ b/transforms/remove-binding/index.js
@@ -15,6 +15,10 @@ module.exports = function transformer(file, api) {
     return path.value.key.name && path.value.key.name.endsWith('Binding');
   });
 
+  if (!nodesWithBindings.length) {
+    return node.toSource();
+  }
+
   let imports = root.find(j.ImportDeclaration);
 
   let computedImports = imports.filter((importt) => {
@@ -27,7 +31,7 @@ module.exports = function transformer(file, api) {
       .get()
       .node.specifiers.filter((specifier) => specifier.imported.name === 'alias');
 
-  if (!alreadyHasAlias[0] && nodesWithBindings.length) {
+  if (!alreadyHasAlias[0]) {
     if (computedImports.length) {
       let aliasSpecifier = j.importSpecifier(j.identifier('alias'));
       computedImports.get().value.specifiers.push(aliasSpecifier);

--- a/transforms/remove-binding/index.js
+++ b/transforms/remove-binding/index.js
@@ -43,9 +43,9 @@ module.exports = function transformer(file, api) {
     }
   }
 
-  nodesWithBindings.forEach((path) => {
-    path.value.value = j.callExpression(j.identifier('alias'), [path.value.value]);
-    path.value.key.name = path.value.key.name.slice(0, -7);
+  nodesWithBindings.forEach(({ value: bindingProp }) => {
+    bindingProp.value = j.callExpression(j.identifier('alias'), [bindingProp.value]);
+    bindingProp.key.name = bindingProp.key.name.slice(0, -7);
   });
   return node.toSource();
 };

--- a/transforms/remove-binding/index.js
+++ b/transforms/remove-binding/index.js
@@ -27,7 +27,9 @@ module.exports = function transformer(file, api) {
 
   let alreadyHasAlias =
     computedImports.length &&
-    computedImports.get().node.specifiers.some((specifier) => specifier.imported.name === 'alias');
+    computedImports.get().node.specifiers.some((specifier) => {
+      return specifier.type === 'ImportSpecifier' && specifier.imported.name === 'alias';
+    });
 
   if (!alreadyHasAlias) {
     if (computedImports.length) {

--- a/transforms/remove-binding/index.js
+++ b/transforms/remove-binding/index.js
@@ -27,11 +27,9 @@ module.exports = function transformer(file, api) {
 
   let alreadyHasAlias =
     computedImports.length &&
-    computedImports
-      .get()
-      .node.specifiers.filter((specifier) => specifier.imported.name === 'alias');
+    computedImports.get().node.specifiers.some((specifier) => specifier.imported.name === 'alias');
 
-  if (!alreadyHasAlias[0]) {
+  if (!alreadyHasAlias) {
     if (computedImports.length) {
       let aliasSpecifier = j.importSpecifier(j.identifier('alias'));
       computedImports.get().value.specifiers.push(aliasSpecifier);

--- a/transforms/remove-binding/index.js
+++ b/transforms/remove-binding/index.js
@@ -1,0 +1,51 @@
+const { getParser } = require('codemod-cli').jscodeshift;
+
+module.exports = function transformer(file, api) {
+  const j = getParser(api);
+
+  const root = j(file.source);
+
+  const node = root.find(j.ObjectProperty, {
+    key: {
+      type: 'Identifier',
+    },
+  });
+
+  let filteredNodes = node.filter((path) => {
+    return path.value.key.name && path.value.key.name.endsWith('Binding');
+  });
+
+  let imports = root.find(j.ImportDeclaration);
+
+  let computedImports = imports.filter((importt) => {
+    return importt.value.source.value === '@ember/object/computed';
+  });
+
+  let alreadyHasAlias =
+    computedImports.length &&
+    computedImports
+      .get()
+      .node.specifiers.filter((specifier) => specifier.imported.name === 'alias');
+
+  if (!alreadyHasAlias[0] && filteredNodes.length) {
+    if (computedImports.length) {
+      let aliasSpecifier = j.importSpecifier(j.identifier('alias'));
+      computedImports.get().value.specifiers.push(aliasSpecifier);
+    } else {
+      const computedImportStatement = `import { alias } from '@ember/object/computed';`;
+      if (imports.length) {
+        j(imports.at(0).get()).insertBefore(computedImportStatement); // before the imports
+      } else {
+        root.get().node.program.body.unshift(computedImportStatement); // begining of file
+      }
+    }
+  }
+
+  filteredNodes.forEach((path) => {
+    path.value.value = j.callExpression(j.identifier('alias'), [path.value.value]);
+    path.value.key.name = path.value.key.name.slice(0, -7);
+  });
+  return node.toSource();
+};
+
+module.exports.type = 'js';

--- a/transforms/remove-binding/test.js
+++ b/transforms/remove-binding/test.js
@@ -1,0 +1,9 @@
+'use strict';
+
+const { runTransformTest } = require('codemod-cli');
+
+runTransformTest({
+  name: 'remove-binding',
+  path: require.resolve('./index.js'),
+  fixtureDir: `${__dirname}/__testfixtures__/`,
+});


### PR DESCRIPTION
Ember 2.7 introduced a new deprecation to EmberBinding https://deprecations.emberjs.com/v2.x#toc_ember-binding. This codemod aims to convert all existing uses of `fooBinding: 'path.to.property'` to `foo: alias('path.to.property')`.

The is additional code that checks if `alias` has already been imported, if not it will import it, If there is already an import statement for `@ember/object/computed` a new statement will not be added but the alias specifier will be added to that statement.
