### PR TITLE
Stop imports from being added to files that are not affected.

### DIFF
--- a/transforms/property-to-computed/__testfixtures__/noProperty.input.js
+++ b/transforms/property-to-computed/__testfixtures__/noProperty.input.js
@@ -1,0 +1,3 @@
+const Person = EmberObject.extend({
+  fullName: "Bob Dylan"
+});

--- a/transforms/property-to-computed/__testfixtures__/noProperty.output.js
+++ b/transforms/property-to-computed/__testfixtures__/noProperty.output.js
@@ -1,0 +1,3 @@
+const Person = EmberObject.extend({
+  fullName: "Bob Dylan"
+});

--- a/transforms/property-to-computed/index.js
+++ b/transforms/property-to-computed/index.js
@@ -23,7 +23,7 @@ module.exports = function transformer(file, api) {
       return specifier.type === 'ImportSpecifier' && specifier.imported.name === 'computed';
     });
 
-  if (!alreadyHasComputed) {
+  if (!alreadyHasComputed && node.length) {
     if (computedImports.length) {
       let computedSpecifier = j.importSpecifier(j.identifier('computed'));
       computedImports.get().value.specifiers.push(computedSpecifier);


### PR DESCRIPTION
This fixes a bug where the computed import is still added to files even if the file does find any instance of `.property` to change.

This also adds a test scenario for this case. 